### PR TITLE
UHF-6959: Workaround for Safari escaped noscrip innerHTML.

### DIFF
--- a/src/components/results/MostReadNews.tsx
+++ b/src/components/results/MostReadNews.tsx
@@ -1,5 +1,5 @@
 const MostReadNews = () => {
-  const mostReadBlocks = document.querySelector('noscript.most-read-news')?.innerHTML;
+  const mostReadBlocks = (document.querySelector('noscript.most-read-news') as HTMLElement)?.innerText;
 
   if (!mostReadBlocks) {
     return null;


### PR DESCRIPTION
# [UHF-6959 Most read safari bug](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6959)
### What was done?

- Fixed issue with escaped html on safari.

### How to install and test

- Build it, copy the built js file to /public/modules/custom/helfi_news_archive/assets in etusivu instance and change the helfi_news_archive.libraries.yml to point to correct js file.
- observe the most read news in sidebar behaves correctly on news page